### PR TITLE
feat: create a test thermometer

### DIFF
--- a/.github/workflows/overflow-test.yaml
+++ b/.github/workflows/overflow-test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Overflow Test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Generate Test Summary
         id: generate-summary
@@ -23,7 +23,7 @@ jobs:
 
       - name: If there is an overflow summary, archive it
         if: ${{steps.generate-summary.outputs.Overflow}}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{steps.generate-summary.outputs.Overflow}}
           path: ${{steps.generate-summary.outputs.Overflow}}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Smoke Test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Generate Test Summary
         id: generate-summary
@@ -18,3 +18,6 @@ jobs:
       - name: If there are alerts, echo them
         if: ${{steps.generate-summary.outputs.alerts}}
         run: echo "${{steps.generate-summary.outputs.alerts}}"
+
+      - name: Echo the thermometer
+        run: echo "${{steps.generate-summary.outputs.thermometer}}"

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Unit test
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
 

--- a/DEVELOPERS_DEVELOPERS_DEVELOPERS.md
+++ b/DEVELOPERS_DEVELOPERS_DEVELOPERS.md
@@ -1,7 +1,24 @@
-# Building and testing locally
+# Building, testing, releasing
 
 The `ciclops` GitHub Action runs using a Docker container that encapsulates the
 Python script that does the CI test analysis.
+
+## Releasing
+
+We recommend that users of Ciclops use released versions rather than `main`.
+For testing, it  may be convenient to [use a full SHA](#testing-within-a-calling-github-workflow).
+
+The procedure for cutting a release:
+
+1. Decide on the version number (following semVer)
+1. Update the [Release notes file](ReleaseNotes.md), following the convention
+  in the file, i.e. the version number included in the section, and the release
+  date in the first line
+1. Review and merge the release notes, and create and push a new tag with the
+  desired version number
+1. Cut a new release in [GitHub](https://github.com/cloudnative-pg/ciclops/releases/new),
+  choosing the recent tag, and pasting the relevant content from the
+  Release Notes file (no need for the release date line).
 
 ## Developing and testing
 
@@ -70,6 +87,22 @@ CIclops has the beginning of a unit test suite. You can run it with:
 
 ``` sh
 python3 -m unittest
+```
+
+## Testing within a calling GitHub workflow
+
+Even with unit tests and local tests, it's good to try Ciclops code out from a
+client workflow. We can use a full length commit SHA to test out changes,
+before cutting out a new release.
+See the [GitHub document on using third party actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).
+
+Example:
+``` yaml
+      - name: Compute the E2E test summary
+        id: generate-summary
+        uses: cloudnative-pg/ciclops@<FULL_LENGTH_SHA>
+        with:
+          artifact_directory: test-artifacts/da
 ```
 
 ## How it works

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Up to three outputs might be produced:
 - `thermometer`: this will contain stand-alone text with a color-coded list
   of test metrics that can serve as an overview of the state of the test suite
   on CI/CD. This is generated on every execution of Ciclops.
-  It is *always* generated.
 
 - `alerts`: this will contain stand-alone text with systematic failures
   detected by CIclops. It is meant to enable further steps in the calling
@@ -106,7 +105,8 @@ There are two advanced cases we want to call attention to:
   color-coded overview of the test health. This thermometer is included in
   the GitHub summary, and in addition, is exported as an output in plain
   text, which can be sent via chatops.
-  In addition, Ciclops will create a series of alerts when systematic failures are detected.
+  In addition, Ciclops will create a series of alerts when systematic failures
+  are detected.
   By "systematic", we mean cases such as:
 
     - all test combinations have failed

--- a/README.md
+++ b/README.md
@@ -20,7 +20,12 @@ watch over Continuous Integration pipelines for all eternity.
 
 ## Outputs
 
-Two outputs might be produced:
+Up to three outputs might be produced:
+
+- `thermometer`: this will contain stand-alone text with a color-coded list
+  of test metrics that can serve as an overview of the state of the test suite
+  on CI/CD. This is generated on every execution of Ciclops.
+  It is *always* generated.
 
 - `alerts`: this will contain stand-alone text with systematic failures
   detected by CIclops. It is meant to enable further steps in the calling
@@ -97,7 +102,11 @@ There are two advanced cases we want to call attention to:
   called `Overflow`.
 
 2. Monitoring with chatops \
-  CIclops will create a series of alerts when systematic failures are detected.
+  Ciclops will generate a "thermometer" on every execution, offering a
+  color-coded overview of the test health. This thermometer is included in
+  the GitHub summary, and in addition, is exported as an output in plain
+  text, which can be sent via chatops.
+  In addition, Ciclops will create a series of alerts when systematic failures are detected.
   By "systematic", we mean cases such as:
 
     - all test combinations have failed
@@ -130,6 +139,13 @@ The following snippet shows how to use these features:
           name: ${{steps.generate-summary.outputs.Overflow}}
           path: ${{steps.generate-summary.outputs.Overflow}}
           retention-days: 7
+
+      - name: Get a slack message with the Ciclops thermometer
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_USERNAME: cnpg-bot
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_MESSAGE: ${{steps.generate-summary.outputs.thermometer}}
 
       - name: If there are alerts, send them over Slack
         if: ${{steps.generate-summary.outputs.alerts}}

--- a/action.yaml
+++ b/action.yaml
@@ -22,6 +22,8 @@ inputs:
 outputs:
   alerts:
     description: 'Any systematic failures found by CIclops'
+  thermometer:
+    description: 'A color-coded health meter'
   Overflow:
     description: 'The name of the file where the full report was written, on oveflow'
 runs:

--- a/example-artifacts/id1_0b185c51a60964ecab5bb7d97458ca95fd421f325f3896ed239d5d3f.json
+++ b/example-artifacts/id1_0b185c51a60964ecab5bb7d97458ca95fd421f325f3896ed239d5d3f.json
@@ -10,7 +10,7 @@
     "postgres_kind": "PostgreSQL",
     "matrix_id": "id1",
     "postgres_version": "11.1",
-    "k8s_version": "22",
+    "k8s_version": "1.22",
     "workflow_id": 12,
     "repo": "my-repo",
     "branch": "my-branch"

--- a/example-artifacts/id1_4902843ff6a60bc4fdb76000698c46de8e7f9763a1a0fe63f70fd5f8.json
+++ b/example-artifacts/id1_4902843ff6a60bc4fdb76000698c46de8e7f9763a1a0fe63f70fd5f8.json
@@ -10,7 +10,7 @@
     "postgres_kind": "PostgreSQL",
     "matrix_id": "id1",
     "postgres_version": "11.1",
-    "k8s_version": "22",
+    "k8s_version": "1.22",
     "workflow_id": 12,
     "repo": "my-repo",
     "branch": "my-branch"

--- a/example-artifacts/id1_9891d0d1caa1ec8fd0adfe622e341f84dd3d1df1cffee843e1fb84a0.json
+++ b/example-artifacts/id1_9891d0d1caa1ec8fd0adfe622e341f84dd3d1df1cffee843e1fb84a0.json
@@ -10,7 +10,7 @@
     "postgres_kind": "PostgreSQL",
     "matrix_id": "id1",
     "postgres_version": "11.1",
-    "k8s_version": "22",
+    "k8s_version": "1.22",
     "workflow_id": 12,
     "repo": "my-repo",
     "branch": "my-branch"

--- a/few-artifacts/id1_0b185c51a60964ecab5bb7d97458ca95fd421f325f3896ed239d5d3f.json
+++ b/few-artifacts/id1_0b185c51a60964ecab5bb7d97458ca95fd421f325f3896ed239d5d3f.json
@@ -10,7 +10,7 @@
     "postgres_kind": "PostgreSQL",
     "matrix_id": "id1",
     "postgres_version": "11.1",
-    "k8s_version": "22",
+    "k8s_version": "1.22",
     "workflow_id": 12,
     "repo": "my-repo",
     "branch": "my-branch"

--- a/few-artifacts/id1_4902843ff6a60bc4fdb76000698c46de8e7f9763a1a0fe63f70fd5f8.json
+++ b/few-artifacts/id1_4902843ff6a60bc4fdb76000698c46de8e7f9763a1a0fe63f70fd5f8.json
@@ -10,7 +10,7 @@
     "postgres_kind": "PostgreSQL",
     "matrix_id": "id1",
     "postgres_version": "11.1",
-    "k8s_version": "22",
+    "k8s_version": "1.22",
     "workflow_id": 12,
     "repo": "my-repo",
     "branch": "my-branch"

--- a/few-artifacts/id1_9891d0d1caa1ec8fd0adfe622e341f84dd3d1df1cffee843e1fb84a0.json
+++ b/few-artifacts/id1_9891d0d1caa1ec8fd0adfe622e341f84dd3d1df1cffee843e1fb84a0.json
@@ -10,7 +10,7 @@
     "postgres_kind": "PostgreSQL",
     "matrix_id": "id1",
     "postgres_version": "11.1",
-    "k8s_version": "22",
+    "k8s_version": "1.22",
     "workflow_id": 12,
     "repo": "my-repo",
     "branch": "my-branch"

--- a/summarize_test_results.py
+++ b/summarize_test_results.py
@@ -632,6 +632,7 @@ def format_thermometer(summary, embed=True, file_out=None):
     """
 
     output = ""
+    # we only test the "by_platform" metric for the thermometer, at the moment
     for metric in ["by_platform"]:
         output += compute_thermometer_on_metric(summary, metric, embed)
 

--- a/summarize_test_results.py
+++ b/summarize_test_results.py
@@ -523,12 +523,12 @@ def compute_systematic_failures_on_metric(summary, metric, embed=True):
             if not has_systematic_failure_in_metric:
                 output += f"{metric_name(metric)} with systematic failures:\n\n"
                 has_systematic_failure_in_metric = True
-            if counter < 2:
-                output += f"- {bucket}: ({failures} out of {runs} tests failed)\n"
-                counter += 1
-            else:
+            if counter >= 2 and not embed:
                 output += f"- ...and more. See full story in GH Test Summary\n"
                 break
+            else:
+                output += f"- {bucket}: ({failures} out of {runs} tests failed)\n"
+                counter += 1
     if has_systematic_failure_in_metric:
         # add a newline after at the end of the list of failures before starting the
         #  next metric

--- a/summarize_test_results.py
+++ b/summarize_test_results.py
@@ -622,16 +622,6 @@ def format_thermometer(summary, embed=True, file_out=None):
     Otherwise, it will be output as plain text intended for stand-alone use.
     """
 
-    if summary["total_run"] == summary["total_failed"]:
-        if embed:
-            print(f"## Alerts\n", file=file_out)
-            print(f"All test combinations failed\n", file=file_out)
-        else:
-            print("alerts<<EOF", file=file_out)
-            print(f"All test combinations failed\n", file=file_out)
-            print("EOF", file=file_out)
-        return
-
     output = ""
     for metric in ["by_platform"]:
         output += compute_thermometer_on_metric(summary, metric, embed)

--- a/summarize_test_results.py
+++ b/summarize_test_results.py
@@ -611,7 +611,7 @@ def compute_thermometer_on_metric(summary, metric, embed=True):
     """
 
     output = f"{metric_name(metric)} thermometer:\n\n"
-    for bucket_hits in summary[metric]["failed"].items():
+    for bucket_hits in summary[metric]["total"].items():
         bucket = bucket_hits[0]  # the items() call returns (bucket, hits) pairs
         failures = summary[metric]["failed"][bucket]
         runs = summary[metric]["total"][bucket]

--- a/summarize_test_results.py
+++ b/summarize_test_results.py
@@ -613,7 +613,9 @@ def compute_thermometer_on_metric(summary, metric, embed=True):
     output = f"{metric_name(metric)} thermometer:\n\n"
     for bucket_hits in summary[metric]["total"].items():
         bucket = bucket_hits[0]  # the items() call returns (bucket, hits) pairs
-        failures = summary[metric]["failed"][bucket]
+        failures = 0
+        if bucket in summary[metric]["failed"]:
+            failures = summary[metric]["failed"][bucket]
         runs = summary[metric]["total"][bucket]
         success_percent = (1 - failures / runs) * 100
         color = compute_semaphore(success_percent, embed)

--- a/summarize_test_results.py
+++ b/summarize_test_results.py
@@ -610,8 +610,7 @@ def compute_thermometer_on_metric(summary, metric, embed=True):
     and a color coding based on said percentage
     """
 
-    output = ""
-    output += f"{metric_name(metric)} thermometer:\n\n"
+    output = f"{metric_name(metric)} thermometer:\n\n"
     for bucket_hits in summary[metric]["failed"].items():
         bucket = bucket_hits[0]  # the items() call returns (bucket, hits) pairs
         failures = summary[metric]["failed"][bucket]

--- a/summarize_test_results.py
+++ b/summarize_test_results.py
@@ -209,7 +209,7 @@ def track_time_taken(test_results, test_times, suite_times):
     if duration < test_times["min"][name]:
         test_times["min"][name] = duration
 
-    # track suite time.
+    # Track test suite timings.
     # For each platform-matrix branch, track the earliest start and the latest end
     platform = test_results["platform"]
     if platform not in suite_times["start_time"]:
@@ -261,7 +261,7 @@ def count_bucketed_by_code(test_results, by_failing_code):
     name = test_results["name"]
     if test_results["error"] == "" or test_results["state"] == "ignoreFailed":
         return
-    # it does not make sense to show failing code that is outside of the test
+    # it does not make sense to show failing code that is outside the test,
     # so we skip special failures
     if not is_normal_failure(test_results):
         return
@@ -493,13 +493,13 @@ def compile_overview(summary):
 
 
 def metric_name(metric):
-    metric_name = {
+    metric_type = {
         "by_test": "Tests",
         "by_k8s": "Kubernetes versions",
         "by_postgres": "Postgres versions",
         "by_platform": "Platforms",
     }
-    return metric_name[metric]
+    return metric_type[metric]
 
 
 def compute_systematic_failures_on_metric(summary, metric, embed=True):
@@ -510,7 +510,7 @@ def compute_systematic_failures_on_metric(summary, metric, embed=True):
 
     The `embed` argument controls the output. If True (default) it computes the full list
     of alerts for the metric. If False, it will cap at 2 rows with alerts, so as not to
-    to flood the chatops client.
+    flood the ChatOps client.
     """
     output = ""
     has_systematic_failure_in_metric = False
@@ -587,7 +587,7 @@ def format_alerts(summary, embed=True, file_out=None):
 def compute_semaphore(success_percent, embed=True):
     """create a semaphore light summarizing the success percent.
     If set to `embed`, an emoji will be used. Else, a textual representation
-    of a slackmoji is used.
+    of a Slack emoji is used.
     """
     if embed:
         if success_percent >= 95:
@@ -617,7 +617,8 @@ def compute_thermometer_on_metric(summary, metric, embed=True):
         runs = summary[metric]["total"][bucket]
         success_percent = (1 - failures / runs) * 100
         color = compute_semaphore(success_percent, embed)
-        output += f"- {color} - {bucket}: {round(success_percent,1)}% success.\t({failures} out of {runs} tests failed)\n"
+        output += f"- {color} - {bucket}: {round(success_percent, 1)}% success.\t"
+        output += f"({failures} out of {runs} tests failed)\n"
     output += f"\n"
     return output
 
@@ -787,7 +788,7 @@ def format_by_code(summary, structure, file_out=None):
 
     for bucket in sorted_by_code:
         tests = ", ".join(summary["by_code"]["tests"][bucket].keys())
-        # replace newlines and pipes to avoid interference with markdown tables
+        # replace newlines and pipes to avoid interference with Markdown tables
         errors = (
             summary["by_code"]["errors"][bucket]
             .replace("\n", "<br />")
@@ -1121,8 +1122,8 @@ if __name__ == "__main__":
             format_test_summary(test_summary, file_out=f)
         if args.limit:
             print("with GITHUB_STEP_SUMMARY limit", args.limit)
-            bytes = os.stat(os.getenv("GITHUB_STEP_SUMMARY")).st_size
-            if bytes > args.limit:
+            summary_bytes = os.stat(os.getenv("GITHUB_STEP_SUMMARY")).st_size
+            if summary_bytes > args.limit:
                 # we re-open the STEP_SUMMARY with "w" to wipe out previous content
                 with open(os.getenv("GITHUB_STEP_SUMMARY"), "w") as f:
                     format_short_test_summary(test_summary, file_out=f)

--- a/test_summary.py
+++ b/test_summary.py
@@ -35,7 +35,8 @@ class TestIsFailed(unittest.TestCase):
             summary["by_code"]["tests"],
             {
                 "/Users/myuser/repos/cloudnative-pg/tests/e2e/initdb_test.go:80": {
-                    "InitDB settings - initdb custom post-init SQL scripts -- can find the tables created by the post-init SQL queries": True
+                    "InitDB settings - initdb custom post-init SQL scripts -- can find the"
+                    " tables created by the post-init SQL queries": True
                 }
             },
             "unexpected summary",

--- a/test_summary.py
+++ b/test_summary.py
@@ -28,9 +28,7 @@ class TestIsFailed(unittest.TestCase):
 
         self.assertEqual(
             summary["by_code"]["total"],
-            {
-                "/Users/myuser/repos/cloudnative-pg/tests/e2e/initdb_test.go:80": 1
-            },
+            {"/Users/myuser/repos/cloudnative-pg/tests/e2e/initdb_test.go:80": 1},
             "unexpected summary",
         )
         self.assertEqual(
@@ -45,7 +43,9 @@ class TestIsFailed(unittest.TestCase):
         self.assertEqual(
             summary["by_matrix"], {"total": {"id1": 3}, "failed": {"id1": 1}}
         )
-        self.assertEqual(summary["by_k8s"], {"total": {"22": 3}, "failed": {"22": 1}})
+        self.assertEqual(
+            summary["by_k8s"], {"total": {"1.22": 3}, "failed": {"1.22": 1}}
+        )
         self.assertEqual(
             summary["by_platform"], {"total": {"local": 3}, "failed": {"local": 1}}
         )


### PR DESCRIPTION
- Introduce a "thermometer" both for the GH summary, and as an
  output that can be used in chatops
- Stop overcounting kubernetes versions and failure rates in them
- Cap the number of alerts shown in chatops (max 2 per metric)
- Update the GH actions dependencies

Closes #9 

![Screenshot 2024-05-30 at 17 47 47](https://github.com/cloudnative-pg/ciclops/assets/423864/5b17588b-0659-46b9-95d5-97c1bc845ed5)


![Screenshot 2024-05-30 at 16 59 06](https://github.com/cloudnative-pg/ciclops/assets/423864/6245a8fb-8745-4f72-8262-2bafa8a49b4b)
