### PR TITLE
fix: do not round up percentages

### DIFF
--- a/summarize_test_results.py
+++ b/summarize_test_results.py
@@ -53,6 +53,7 @@ a summary in Markdown, which can then be rendered in GitHub using
 import argparse
 from datetime import datetime
 import json
+import math
 import os
 import pathlib
 from prettytable import MARKDOWN
@@ -628,7 +629,9 @@ def compute_thermometer_on_metric(summary, metric, embed=True):
         runs = summary[metric]["total"][bucket]
         success_percent = (1 - failures / runs) * 100
         color = compute_semaphore(success_percent, embed)
-        output += f"- {color} - {bucket}: {round(success_percent, 1)}% success.\t"
+        output += (
+            f"- {color} - {bucket}: {math.floor(success_percent*10)/10}% success.\t"
+        )
         output += f"({failures} out of {runs} tests failed)\n"
     output += f"\n"
     return output

--- a/test_summary.py
+++ b/test_summary.py
@@ -76,7 +76,7 @@ class TestIsFailed(unittest.TestCase):
         self.assertEqual(
             thermometer,
             "Platforms thermometer:\n\n"
-            "- 🔴 - local: 66.7% success.\t(1 out of 3 tests failed)\n\n",
+            "- 🔴 - local: 66.6% success.\t(1 out of 3 tests failed)\n\n",
         )
 
         thermometerPlaintext = summarize_test_results.compute_thermometer_on_metric(
@@ -86,7 +86,7 @@ class TestIsFailed(unittest.TestCase):
         self.assertEqual(
             thermometerPlaintext,
             "Platforms thermometer:\n\n"
-            "- :red_circle: - local: 66.7% success.\t(1 out of 3 tests failed)\n\n",
+            "- :red_circle: - local: 66.6% success.\t(1 out of 3 tests failed)\n\n",
         )
 
     def test_compute_systematic_failures(self):


### PR DESCRIPTION
Sometimes, the report contains lines like the following

- 🟢 - local: 100.0% success.    (3 out of 7151 tests failed)

It is weird to see failures when the percentage says 100% success.

This patch fixes the issue by always rounding down the success percentage to the first decimal.