### PR TITLE
chore: update docker image and CI dependencies

### DIFF
--- a/.github/workflows/overflow-test.yaml
+++ b/.github/workflows/overflow-test.yaml
@@ -7,12 +7,16 @@ defaults:
     # default failure handling for shell scripts in 'run' steps
     shell: 'bash -Eeuo pipefail -x {0}'
 
+permissions: {}
+
 jobs:
   overflow_test:
     runs-on: ubuntu-latest
     name: Overflow Test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          persist-credentials: false
 
       - name: Generate Test Summary
         id: generate-summary

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,12 +2,16 @@ name: Smoke Test
 
 on: [push]
 
+permissions: {}
+
 jobs:
   smoke_test:
     runs-on: ubuntu-latest
     name: Smoke Test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          persist-credentials: false
 
       - name: Generate Test Summary
         id: generate-summary
@@ -16,8 +20,12 @@ jobs:
           artifact_directory: example-artifacts/
 
       - name: If there are alerts, echo them
-        if: ${{steps.generate-summary.outputs.alerts}}
-        run: echo "${{steps.generate-summary.outputs.alerts}}"
+        if: ${{ steps.generate-summary.outputs.alerts }}
+        env:
+          ALERTS: ${{ steps.generate-summary.outputs.alerts }}
+        run: echo "$ALERTS"
 
       - name: Echo the thermometer
-        run: echo "${{steps.generate-summary.outputs.thermometer}}"
+        env:
+          THERMOMETER: ${{ steps.generate-summary.outputs.thermometer }}
+        run: echo "$THERMOMETER"

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -2,20 +2,24 @@ name: Unit Test
 
 on: [push]
 
+permissions: {}
+
 jobs:
   unit_test:
     runs-on: ubuntu-latest
     name: Unit test
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          persist-credentials: false
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.x'
+      - name: Set up Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6
+        with:
+          python-version: '3.x'
 
-    - name: Install dependencies
-      run: python -m pip install --upgrade pip prettytable
+      - name: Install dependencies
+        run: python -m pip install --upgrade pip prettytable
 
-    - name: Run suite
-      run: python test_summary.py -v
+      - name: Run suite
+        run: python test_summary.py -v

--- a/DEVELOPERS_DEVELOPERS_DEVELOPERS.md
+++ b/DEVELOPERS_DEVELOPERS_DEVELOPERS.md
@@ -103,7 +103,7 @@ Example:
         id: generate-summary
         uses: cloudnative-pg/ciclops@<FULL_LENGTH_SHA>
         with:
-          artifact_directory: test-artifacts/da
+          artifact_directory: test-artifacts
 ```
 
 ## How it works

--- a/DEVELOPERS_DEVELOPERS_DEVELOPERS.md
+++ b/DEVELOPERS_DEVELOPERS_DEVELOPERS.md
@@ -108,20 +108,16 @@ Example:
 
 ## How it works
 
-The files in this repository are needed for the Dockerfile to build and run, of
-course. In addition, GitHub will copy the files in the **user's** GitHub
-workflow location to the Dockerfile too. This is how the folder with the JSON
-artifacts will get passed. When invoking with `act`, we are simulating this with
-the `-b` option.
+`summarize_test_results.py` and its `requirements.txt` are needed for the
+Dockerfile to build and run.
+In addition, at runtime GitHub will copy the files in the **user's**
+`GITHUB_WORKSPACE` directory to the Dockerfile, by running the container with a
+bind mount similar to the following one:
 
-In the Dockerfile, the `COPY . .` line will include the directory with the
-JSON test artifacts at build time.
-See [GitHub support for Dockerfile](https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions):
+```
+-v "/home/runner/work/ciclops/ciclops":"/github/workspace"
+```
 
-> Before the action executes, GitHub will mount the GITHUB_WORKSPACE directory
-> on top of anything that was at that location in the Docker image and set
-> GITHUB_WORKSPACE as the working directory.
-
-**NOTE**: the behavior of the `COPY` command in Dockerfiles seems quite
-finicky on whether it's done recursively or not. The invocation used,
-`COPY . .`, ensures the copy is done recursively.
+and it will use that as the container's `WORKDIR`.
+This is how the folder with the JSON artifacts will get passed.
+When invoking with `act`, we are simulating this with the `-b` option.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.14-alpine
 
 COPY requirements.txt ./
+COPY summarize_test_results.py ./
 RUN pip install --no-cache-dir -r requirements.txt
-COPY . .
 
 ENTRYPOINT [ "python", "/summarize_test_results.py"]
 CMD ["--dir", "./test-artifacts"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM python:3
-
-# WORKDIR /usr/src/app
+FROM python:3.14-alpine
 
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -63,28 +63,22 @@ For example:
     …
     …
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Create a directory for the artifacts
         run: mkdir test-artifacts
 
       - name: Download all artifacts to the directory
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v6
         with:
           path: test-artifacts
-
-      - name: Flatten all artifacts onto directory
-        # The download-artifact action, since we did not give it a name,
-        # downloads all artifacts and creates a new folder for each.
-        # In this step we bring all the JSONs to a single folder
-        run: |
-            mkdir test-artifacts/data
-            mv test-artifacts/*/*.json test-artifacts/data
+          pattern: testartifacts-*
+          merge-multiple: true
 
       - name: Compute the E2E test summary
         uses: cloudnative-pg/ciclops@main
         with:
-          artifact_directory: test-artifacts/data
+          artifact_directory: test-artifacts
 ```
 
 ## Advanced Usage
@@ -130,7 +124,7 @@ The following snippet shows how to use these features:
         id: generate-summary
         uses: cloudnative-pg/ciclops@main
         with:
-          artifact_directory: test-artifacts/data
+          artifact_directory: test-artifacts
 
       - name: If there is an overflow summary, archive it
         if: ${{steps.generate-summary.outputs.Overflow}}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "docker:pinDigests"
+  ],
+  "enabledManagers": [
+    "github-actions"
+  ]
+}


### PR DESCRIPTION
CI related work:
* Added a renovate minimal config
* Updated the actions to use SHA256 digests
* Removed unnecessary permissions from the workflows

Dockerfile:
* Use alpine instead of the Debian-based image (`72MB` vs `1.61GB`)
* Copy just `summarize_test_results.py` instead of the whole directory

README:
* Suggest using `actions/download-artifact`'s `merge-multiple: true` option to flatten the artifacts
   in a single folder instead of doing it manually